### PR TITLE
use specified font stack as font-family

### DIFF
--- a/src/resources/styles.css
+++ b/src/resources/styles.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+  --default-font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --background-primary: #262626;


### PR DESCRIPTION
...rather than overriding font-family with undeclared variable.

this will make the text look like this, instead of the browser default font viewers have set (typically a serif font):
<img width="871" alt="Screenshot 2023-02-27 at 12 43 24 PM" src="https://user-images.githubusercontent.com/5727389/221641771-e8c0a75a-c40d-4486-a0c8-d2ef6c300b1c.png">
