### PR TITLE
Tags

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -815,13 +815,31 @@ fn generateTagPages(
             }
         }.inner);
 
+        try writer.print("<div class=\"tag-page\">", .{});
+
         for (entry.value_ptr.items) |page| {
             // TODO escape data
+            var page_fd = try std.fs.cwd().openFile(
+                page.filesystem_path,
+                .{ .mode = .read_only },
+            );
+            defer page_fd.close();
+            var preview_buffer: [256]u8 = undefined;
+            const page_preview_text_read_bytes = try page_fd.read(&preview_buffer);
+            const page_preview_text = preview_buffer[0..page_preview_text_read_bytes];
             try writer.print(
-                "<a href=\"{s}{s}\">{s}</a><p>",
-                .{ build_file.config.webroot, page.web_path.?, page.title },
+                \\ <div class="page-preview">
+                \\ 	<a href="{s}{s}">
+                \\ 		<div class="page-preview-title"><h2>{s}</h2></div>
+                \\ 		<div class="page-preview-text">{s}</div>
+                \\ 	</a>
+                \\ </div><p>
+            ,
+                .{ build_file.config.webroot, page.web_path.?, page.title, page_preview_text },
             );
         }
+
+        try writer.print("</div>", .{});
 
         _ = try writer.write(
             \\  </main>

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,9 @@ const libpcre = @import("libpcre");
 
 const StringList = std.ArrayList(u8);
 const BuildFile = @import("build_file.zig").BuildFile;
+const processors = @import("processors.zig");
+
+const logger = std.log.scoped(.obsidian2web);
 
 const PageBuildStatus = enum {
     Unbuilt,
@@ -14,6 +17,7 @@ const PageBuildStatus = enum {
 const Page = struct {
     filesystem_path: []const u8,
     title: []const u8,
+    // TODO change this to union(enum)
     status: PageBuildStatus = .Unbuilt,
     html_path: ?[]const u8 = null,
     web_path: ?[]const u8 = null,
@@ -106,9 +110,10 @@ fn addFilePage(
     try pages.put(local_path, Page{ .filesystem_path = fspath, .title = title });
     try tree.addPage(local_path);
 }
-const StringBuffer = std.ArrayList(u8);
+pub const StringBuffer = std.ArrayList(u8);
 
-fn encodeForHTML(allocator: std.mem.Allocator, in: []const u8) ![]const u8 {
+// TODO move to util
+pub fn encodeForHTML(allocator: std.mem.Allocator, in: []const u8) ![]const u8 {
     var result = StringList.init(allocator);
     defer result.deinit();
 
@@ -126,103 +131,13 @@ fn encodeForHTML(allocator: std.mem.Allocator, in: []const u8) ![]const u8 {
     return try result.toOwnedSlice();
 }
 
-const ProcessorContext = struct {
+pub const ProcessorContext = struct {
     build_file: *const BuildFile,
     titles: *TitleMap,
     pages: *PageMap,
     captures: []?libpcre.Capture,
     file_contents: []const u8,
     current_html_path: []const u8,
-};
-
-const CheckmarkProcessor = struct {
-    regex: libpcre.Regex,
-
-    const Self = @This();
-
-    pub fn deinit(self: *Self) void {
-        self.regex.deinit();
-    }
-
-    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
-        _ = self;
-        const match = ctx.captures[0].?;
-        const check = ctx.file_contents[match.start..match.end];
-        try result.writer().print("<code>{s}</code>", .{check});
-    }
-};
-
-const LinkProcessor = struct {
-    regex: libpcre.Regex,
-
-    const Self = @This();
-
-    pub fn deinit(self: *Self) void {
-        self.regex.deinit();
-    }
-
-    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
-        _ = self;
-        const match = ctx.captures[0].?;
-
-        std.log.info("match {} {}", .{ match.start, match.end });
-        const referenced_title = ctx.file_contents[match.start + 2 .. match.end - 2];
-        std.log.info("link to '{s}'", .{referenced_title});
-
-        var maybe_page_local_path = ctx.titles.get(referenced_title);
-        if (maybe_page_local_path) |page_local_path| {
-            var page = ctx.pages.get(page_local_path).?;
-            const safe_referenced_title = try encodeForHTML(result.allocator, referenced_title);
-            defer result.allocator.free(safe_referenced_title);
-            try result.writer().print(
-                "<a href=\"{s}/{?s}\">{s}</a>",
-                .{
-                    ctx.build_file.config.webroot,
-                    page.web_path,
-                    safe_referenced_title,
-                },
-            );
-        } else {
-            if (ctx.build_file.config.strict_links) {
-                std.log.err(
-                    "file '{s}' has link to file '{s}' which is not included!",
-                    .{ ctx.current_html_path, referenced_title },
-                );
-                return error.InvalidLinksFound;
-            } else {
-                try result.writer().print("[[{s}]]", .{referenced_title});
-            }
-        }
-    }
-};
-
-const WebLinkProcessor = struct {
-    regex: libpcre.Regex,
-
-    const Self = @This();
-
-    pub fn deinit(self: *Self) void {
-        self.regex.deinit();
-    }
-
-    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
-        _ = self;
-        const full_match = ctx.captures[0].?;
-        const first_character = ctx.file_contents[full_match.start .. full_match.start + 1];
-
-        const match = ctx.captures[1].?;
-
-        std.log.info("link match {} {}", .{ match.start, match.end });
-        const web_link = ctx.file_contents[match.start..match.end];
-        std.log.info("text web link to '{s}' (first char '{s}')", .{ web_link, first_character });
-
-        const safe_web_link = try encodeForHTML(result.allocator, web_link);
-        defer result.allocator.free(safe_web_link);
-        try result.writer().print(
-            "{s}<a href=\"{s}\">{s}</a>",
-            .{ first_character, web_link, safe_web_link },
-        );
-    }
 };
 
 const Paths = struct {
@@ -474,6 +389,8 @@ pub fn main() anyerror!void {
     var vault_dir = try std.fs.cwd().openIterableDir(build_file.vault_path, .{});
     defer vault_dir.close();
 
+    // TODO move to a Context entity
+
     var pages = PageMap.init(alloc);
     defer pages.deinit();
 
@@ -487,8 +404,14 @@ pub fn main() anyerror!void {
     var tree = PageTree.init(alloc);
     defer tree.deinit();
 
+    // resolve all paths given in include directives into Page entities
+    // in the relevant maps (also including title and tree)
+
     for (build_file.includes.items) |include_path| {
-        const joined_path = try std.fs.path.resolve(alloc, &[_][]const u8{ build_file.vault_path, include_path });
+        const joined_path = try std.fs.path.resolve(
+            alloc,
+            &[_][]const u8{ build_file.vault_path, include_path },
+        );
         defer alloc.free(joined_path);
 
         std.log.info("include path: {s}", .{joined_path});
@@ -523,19 +446,8 @@ pub fn main() anyerror!void {
         }
     }
 
-    const resources = .{ .{ "resources/styles.css", "styles.css" }, .{ "resources/main.js", "main.js" } };
-
-    inline for (resources) |resource| {
-        const resource_text = @embedFile(resource.@"0");
-
-        const resource_fspath = "public/" ++ resource.@"1";
-        const leading_path_to_file = std.fs.path.dirname(resource_fspath).?;
-        try std.fs.cwd().makePath(leading_path_to_file);
-
-        var resource_fd = try std.fs.cwd().createFile(resource_fspath, .{ .truncate = true });
-        defer resource_fd.close();
-        _ = try resource_fd.write(resource_text);
-    }
+    try std.fs.cwd().makePath("public/");
+    try createStaticResources();
 
     var pages_it = pages.iterator();
 
@@ -543,12 +455,17 @@ pub fn main() anyerror!void {
     defer toc_result.deinit();
 
     var toc_ctx: TocContext = .{};
-    try generateToc(&toc_result, &build_file, &pages, &tree.root.getPtr(".").?.dir, &toc_ctx, null);
+    try generateToc(
+        &toc_result,
+        &build_file,
+        &pages,
+        &tree.root.getPtr(".").?.dir,
+        &toc_ctx,
+        null,
+    );
 
     const toc = try toc_result.toOwnedSlice();
     defer alloc.free(toc);
-
-    const webroot = build_file.config.webroot;
 
     // first pass: use koino to parse all that markdown into html
     while (pages_it.next()) |entry| {
@@ -557,10 +474,16 @@ pub fn main() anyerror!void {
         const fspath = entry.value_ptr.*.filesystem_path;
 
         std.log.info("processing '{s}'", .{fspath});
-        var page_fd = try std.fs.cwd().openFile(fspath, .{ .mode = .read_only });
+        var page_fd = try std.fs.cwd().openFile(
+            fspath,
+            .{ .mode = .read_only },
+        );
         defer page_fd.close();
 
-        const file_contents = try page_fd.reader().readAllAlloc(alloc, std.math.maxInt(usize));
+        const file_contents = try page_fd.reader().readAllAlloc(
+            alloc,
+            std.math.maxInt(usize),
+        );
         defer alloc.free(file_contents);
 
         var p = try koino.parser.Parser.init(alloc, .{});
@@ -581,21 +504,14 @@ pub fn main() anyerror!void {
 
         const safe_title = try encodeForHTML(alloc, page.title);
         defer alloc.free(safe_title);
-        try result.writer().print(
-            \\<!DOCTYPE html>
-            \\<html lang="en">
-            \\  <head>
-            \\    <meta charset="UTF-8">
-            \\    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            \\    <title>{s}</title>
-            \\    <script src="{s}/main.js"></script>
-            \\    <link rel="stylesheet" href="{s}/styles.css">
-            \\  </head>
-            \\  <body>
-            \\  <nav class="toc">
-        , .{ safe_title, webroot, webroot });
+        try writeHead(result.writer(), build_file, safe_title);
 
-        const pageToc = try tocForPage(&build_file, &pages, &tree, paths.web_path);
+        const pageToc = try tocForPage(
+            &build_file,
+            &pages,
+            &tree,
+            paths.web_path,
+        );
         defer alloc.free(pageToc);
 
         try result.appendSlice(pageToc);
@@ -635,25 +551,34 @@ pub fn main() anyerror!void {
         entry.value_ptr.*.web_path = try string_arena.dupe(u8, paths.web_path);
         entry.value_ptr.*.status = .Built;
     }
-    const link_processor = LinkProcessor{
+    const link_processor = processors.LinkProcessor{
         .regex = try libpcre.Regex.compile("\\[\\[.+\\]\\]", .{}),
     };
-    const check_processor = CheckmarkProcessor{
+    const check_processor = processors.CheckmarkProcessor{
         .regex = try libpcre.Regex.compile("\\[.\\]", .{}),
     };
-    const web_link_processor = WebLinkProcessor{
+    const web_link_processor = processors.WebLinkProcessor{
         .regex = try libpcre.Regex.compile("[> ](https?:\\/\\/[a-zA-Z0-9\\./_\\-#\\?=]+)", .{}),
     };
+    //const tag_processor = processors.TagProcessor{
+    //    .regex = try libpcre.Regex.compile("#\S+", .{}),
+    //};
 
-    const processors = .{
+    const PROCESSORS = .{
         link_processor,
         check_processor,
         web_link_processor,
+        // tag_processor,
     };
 
+    // run each processor over the file's contents
+    // this generalizes on the regex matching code so that all processors
+    // are just called back when we want to get a replacement text on
+    // top of them
+
     comptime var i = 0;
-    inline while (i < processors.len) : (i += 1) {
-        var processor = processors[i];
+    inline while (i < PROCESSORS.len) : (i += 1) {
+        var processor = PROCESSORS[i];
         defer processor.deinit();
 
         var link_pages_it = pages.iterator();
@@ -661,19 +586,31 @@ pub fn main() anyerror!void {
             const page = entry.value_ptr.*;
             try std.testing.expectEqual(PageBuildStatus.Built, page.status);
             const html_path = entry.value_ptr.html_path.?;
-            std.log.info("running {s} for file '{s}'", .{ @typeName(@TypeOf(processor)), html_path });
+            logger.info(
+                "running {s} for file '{s}'",
+                .{ @typeName(@TypeOf(processor)), html_path },
+            );
 
-            var file_contents_mut: []const u8 = undefined;
-            {
-                var page_fd = try std.fs.cwd().openFile(html_path, .{ .mode = .read_only });
+            const file_contents = blk: {
+                var page_fd = try std.fs.cwd().openFile(
+                    html_path,
+                    .{ .mode = .read_only },
+                );
                 defer page_fd.close();
 
-                file_contents_mut = try page_fd.reader().readAllAlloc(alloc, std.math.maxInt(usize));
-            }
-            const file_contents = file_contents_mut;
+                break :blk try page_fd.reader().readAllAlloc(
+                    alloc,
+                    std.math.maxInt(usize),
+                );
+            };
             defer alloc.free(file_contents);
 
-            const matches = try captureAll(processor.regex, alloc, file_contents, .{});
+            const matches = try captureAll(
+                processor.regex,
+                alloc,
+                file_contents,
+                .{},
+            );
             defer {
                 for (matches.items) |match| alloc.free(match);
                 matches.deinit();
@@ -693,9 +630,13 @@ pub fn main() anyerror!void {
             for (matches.items) |captures| {
                 const match = captures[0].?;
                 _ = if (last_match == null)
-                    try result.writer().write(file_contents[0..match.start])
+                    try result.writer().write(
+                        file_contents[0..match.start],
+                    )
                 else
-                    try result.writer().write(file_contents[last_match.?.end..match.start]);
+                    try result.writer().write(
+                        file_contents[last_match.?.end..match.start],
+                    );
 
                 var ctx = ProcessorContext{
                     .build_file = &build_file,
@@ -706,16 +647,22 @@ pub fn main() anyerror!void {
                     .current_html_path = html_path,
                 };
 
+                // processor callback is run here!
                 try processor.handle(ctx, &result);
                 last_match = match;
             }
 
-            // last_match.?.end to end of file
+            // if we're at the end of the file and there's no matches
+            // to make anymore, just copy paste the rest
 
             _ = if (last_match == null)
-                try result.writer().write(file_contents[0..file_contents.len])
+                try result.writer().write(
+                    file_contents[0..file_contents.len],
+                )
             else
-                try result.writer().write(file_contents[last_match.?.end..file_contents.len]);
+                try result.writer().write(
+                    file_contents[last_match.?.end..file_contents.len],
+                );
 
             {
                 var page_fd = try std.fs.cwd().openFile(
@@ -728,12 +675,18 @@ pub fn main() anyerror!void {
             }
         }
     }
+
+    // generate index file
     {
-        const index_out_fd = try std.fs.cwd().createFile("public/index.html", .{ .truncate = true });
+        const index_out_fd = try std.fs.cwd().createFile(
+            "public/index.html",
+            .{ .truncate = true },
+        );
         defer index_out_fd.close();
 
+        // if an index file was provided in the config, copypaste the resulting
+        // HTML as that'll work
         if (build_file.config.index) |path_to_index_file| {
-            // just copy the html into index.html LOL
             var path_buffer: [2048]u8 = undefined;
             const paths = try parsePaths(path_to_index_file, &path_buffer);
 
@@ -746,41 +699,71 @@ pub fn main() anyerror!void {
 
             try std.testing.expect(written_bytes > 0);
         } else {
-            // generate our own empty file that contains the table of contents
+            // if not, generate our own empty file
+            // that contains just the table of contents
 
             const writer = index_out_fd.writer();
 
-            try writer.print(
-                \\<!DOCTYPE html>
-                \\<html lang="en">
-                \\  <head>
-                \\    <meta charset="UTF-8">
-                \\    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                \\    <title>{s}</title>
-                \\    <script src="/main.js"></script>
-                \\    <link rel="stylesheet" href="/styles.css">
-                \\  </head>
-                \\  <body>
-                \\  <nav class="toc">
-            , .{"Index Page"});
-
+            try writeHead(writer, build_file, "Index Page");
             _ = try writer.write(toc);
-
-            _ = try writer.write(
-                \\  </nav>
-                \\  <main class="text">
-                \\  </main>
-            );
-
-            if (build_file.config.project_footer) {
-                _ = try writer.write(FOOTER);
-            }
-
-            _ = try writer.write(
-                \\  </body>
-                \\</html>
-            );
+            try writeEmptyPage(writer, build_file);
         }
+    }
+}
+
+fn writeHead(writer: anytype, build_file: BuildFile, title: []const u8) !void {
+    try writer.print(
+        \\<!DOCTYPE html>
+        \\<html lang="en">
+        \\  <head>
+        \\    <meta charset="UTF-8">
+        \\    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        \\    <title>{s}</title>
+        \\    <script src="{s}/main.js"></script>
+        \\    <link rel="stylesheet" href="{s}/styles.css">
+        \\  </head>
+        \\  <body>
+        \\  <nav class="toc">
+    , .{ title, build_file.config.webroot, build_file.config.webroot });
+}
+
+// TODO make this usable on the main pipeline too?
+fn writeEmptyPage(writer: anytype, build_file: BuildFile) !void {
+    _ = try writer.write(
+        \\  </nav>
+        \\  <main class="text">
+        \\  </main>
+    );
+
+    if (build_file.config.project_footer) {
+        _ = try writer.write(FOOTER);
+    }
+
+    _ = try writer.write(
+        \\  </body>
+        \\</html>
+    );
+}
+
+fn createStaticResources() !void {
+    const RESOURCES = .{
+        .{ "resources/styles.css", "styles.css" },
+        .{ "resources/main.js", "main.js" },
+    };
+
+    inline for (RESOURCES) |resource| {
+        const resource_text = @embedFile(resource.@"0");
+
+        const output_fspath = "public/" ++ resource.@"1";
+
+        var output_fd = try std.fs.cwd().createFile(
+            output_fspath,
+            .{ .truncate = true },
+        );
+        defer output_fd.close();
+        // write it all lmao
+        const written_bytes = try output_fd.write(resource_text);
+        std.debug.assert(written_bytes == resource_text.len);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -815,6 +815,8 @@ fn generateTagPages(
             }
         }.inner);
 
+        try writer.print("<h1>{s}</h1><p>", .{safe_title});
+        try writer.print("({d} pages)", .{entry.value_ptr.items.len});
         try writer.print("<div class=\"tag-page\">", .{});
 
         for (entry.value_ptr.items) |page| {

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -100,11 +100,15 @@ pub const WebLinkProcessor = struct {
 pub const TagProcessor = struct {
     regex: libpcre.Regex,
 
+    // why doesnt this work on tags in the beginning of the line
     const REGEX: [:0]const u8 = "( |^)#[a-zA-Z0-9-_]+";
     const Self = @This();
 
     pub fn init() !Self {
-        return Self{ .regex = try libpcre.Regex.compile(REGEX, .{}) };
+        return Self{ .regex = try libpcre.Regex.compile(
+            REGEX,
+            .{ .Multiline = true },
+        ) };
     }
 
     pub fn deinit(self: Self) void {

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const libpcre = @import("libpcre");
+const root = @import("root");
+const ProcessorContext = root.ProcessorContext;
+const StringBuffer = root.StringBuffer;
+const logger = std.log.scoped(.obsidian2web_processors);
+const encodeForHTML = root.encodeForHTML;
+
+pub const CheckmarkProcessor = struct {
+    regex: libpcre.Regex,
+
+    const Self = @This();
+
+    pub fn deinit(self: *Self) void {
+        self.regex.deinit();
+    }
+
+    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
+        _ = self;
+        const match = ctx.captures[0].?;
+        const check = ctx.file_contents[match.start..match.end];
+        try result.writer().print("<code>{s}</code>", .{check});
+    }
+};
+
+pub const LinkProcessor = struct {
+    regex: libpcre.Regex,
+
+    const Self = @This();
+
+    pub fn deinit(self: *Self) void {
+        self.regex.deinit();
+    }
+
+    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
+        _ = self;
+        const match = ctx.captures[0].?;
+
+        logger.info("match {} {}", .{ match.start, match.end });
+        const referenced_title = ctx.file_contents[match.start + 2 .. match.end - 2];
+        logger.info("link to '{s}'", .{referenced_title});
+
+        var maybe_page_local_path = ctx.titles.get(referenced_title);
+        if (maybe_page_local_path) |page_local_path| {
+            var page = ctx.pages.get(page_local_path).?;
+            const safe_referenced_title = try encodeForHTML(result.allocator, referenced_title);
+            defer result.allocator.free(safe_referenced_title);
+            try result.writer().print(
+                "<a href=\"{s}/{?s}\">{s}</a>",
+                .{
+                    ctx.build_file.config.webroot,
+                    page.web_path,
+                    safe_referenced_title,
+                },
+            );
+        } else {
+            if (ctx.build_file.config.strict_links) {
+                logger.err(
+                    "file '{s}' has link to file '{s}' which is not included!",
+                    .{ ctx.current_html_path, referenced_title },
+                );
+                return error.InvalidLinksFound;
+            } else {
+                try result.writer().print("[[{s}]]", .{referenced_title});
+            }
+        }
+    }
+};
+
+pub const WebLinkProcessor = struct {
+    regex: libpcre.Regex,
+
+    const Self = @This();
+
+    pub fn deinit(self: *Self) void {
+        self.regex.deinit();
+    }
+
+    pub fn handle(self: *Self, ctx: ProcessorContext, result: *StringBuffer) !void {
+        _ = self;
+        const full_match = ctx.captures[0].?;
+        const first_character = ctx.file_contents[full_match.start .. full_match.start + 1];
+
+        const match = ctx.captures[1].?;
+
+        logger.info("link match {} {}", .{ match.start, match.end });
+        const web_link = ctx.file_contents[match.start..match.end];
+        logger.info("text web link to '{s}' (first char '{s}')", .{ web_link, first_character });
+
+        const safe_web_link = try encodeForHTML(result.allocator, web_link);
+        defer result.allocator.free(safe_web_link);
+        try result.writer().print(
+            "{s}<a href=\"{s}\">{s}</a>",
+            .{ first_character, web_link, safe_web_link },
+        );
+    }
+};

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -121,7 +121,6 @@ pub const TagProcessor = struct {
         // rather than doing it in code like this lmao
 
         const first_character = if (full_match.start == 0) ' ' else ctx.file_contents[full_match.start - 1];
-        logger.info("fristt char '{s}'", .{&[_]u8{first_character}});
         if (first_character != ' ' and first_character != '>') {
             return try result.writer().print("{s}", .{raw_text});
         }
@@ -132,7 +131,7 @@ pub const TagProcessor = struct {
         // tag index pages will be generated after processor finishes
         try ctx.current_page.tags.append(try ctx.allocator.dupe(u8, tag_name));
 
-        logger.info("tag: {s} {s}", .{ tag_text, tag_name });
+        logger.info("found tag: {s} {s}", .{ tag_text, tag_name });
         try result.writer().print(
             "{s}<a href=\"{s}/_/tags/{s}.html\">{s}</a>",
             .{

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -119,7 +119,7 @@ pub const TagProcessor = struct {
         const tag_name = tag_text[1..];
 
         // tag index pages will be generated after processor finishes
-        try ctx.current_page.tags.append(try ctx.allocator.dupe(u8, tag_text));
+        try ctx.current_page.tags.append(try ctx.allocator.dupe(u8, tag_name));
 
         logger.info("tag: {s} {s}", .{ tag_text, tag_name });
         try result.writer().print(

--- a/src/resources/styles.css
+++ b/src/resources/styles.css
@@ -119,3 +119,20 @@ nav li:has(a[aria-current="page"]) {
   font-weight: bold;
   color: #66b0ff;
 }
+
+.tag-page {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.page-preview {
+  border-style: solid;
+  border-width: 4px;
+  border-color: #888888;
+  width: 25rem;
+  flex: 1 0 30rem;
+}
+
+.page-preview-text {
+  color: white;
+}

--- a/src/resources/styles.css
+++ b/src/resources/styles.css
@@ -130,7 +130,8 @@ nav li:has(a[aria-current="page"]) {
   border-width: 4px;
   border-color: #888888;
   width: 25rem;
-  flex: 1 0 30rem;
+  flex: 0 0 30rem;
+  padding: 2rem;
 }
 
 .page-preview-text {

--- a/src/util.zig
+++ b/src/util.zig
@@ -29,6 +29,7 @@ fn encodeForHTML(writer: anytype, in: []const u8) !void {
             '>' => try writer.write("&gt;"),
             '"' => try writer.write("&quot;"),
             '\'' => try writer.write("&#x27;"),
+            '\\' => try writer.write("&#92;"),
             else => try writer.writeByte(char),
         };
     }

--- a/src/util.zig
+++ b/src/util.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+pub fn unsafeHTML(data: []const u8) UnsafeHTMLPrinter {
+    return UnsafeHTMLPrinter{ .data = data };
+}
+
+pub const UnsafeHTMLPrinter = struct {
+    data: []const u8,
+
+    const Self = @This();
+
+    pub fn format(
+        value: Self,
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = options;
+        _ = fmt;
+        try encodeForHTML(writer, value.data);
+    }
+};
+
+fn encodeForHTML(writer: anytype, in: []const u8) !void {
+    for (in) |char| {
+        _ = switch (char) {
+            '&' => try writer.write("&amp;"),
+            '<' => try writer.write("&lt;"),
+            '>' => try writer.write("&gt;"),
+            '"' => try writer.write("&quot;"),
+            '\'' => try writer.write("&#x27;"),
+            else => try writer.writeByte(char),
+        };
+    }
+}


### PR DESCRIPTION
close #5 

implementing the little tag box in each article would be a mess to implement because `TagProcessor` runs on the final HTML instead of the initial markdown, and we'd need that information to be able to even generate the page's HTML. it'd be a refactor of how we currently extend the koino's syntax, and i'm not ready to take that in yet