### PR TITLE
fix(css): Add left side margin

### DIFF
--- a/src/resources/styles.css
+++ b/src/resources/styles.css
@@ -174,7 +174,7 @@ nav li:has(a[aria-current="page"]) {
     padding-right: 2rem;
   }
   .text {
-    margin: 0 auto 2rem 0;
+    margin: 0 auto 2rem 1%;
     max-width: 50rem;
   }
   footer {


### PR DESCRIPTION
Observed [here](https://l4.pm/wiki/Personal%20Wiki/AI%20stuff/understanding%20anime%20taggers.html), The text is uncomfortably close to the scrollbar of the sidebar. 
On KDE Firefox, this isn't incredibly disruptive because the sidebar gets hidden when not focused. The text is still close to the rather slim scrollbar though,
![Screenshot_20230804_211553](https://github.com/lun-4/obsidian2web/assets/126194895/4ddda382-ada0-4e22-a73e-7b464f43c0b8)

The scrollbar on Windows however is incredibly thick, doesn't hide and cuts into the text on the right side.
![image](https://github.com/lun-4/obsidian2web/assets/126194895/0a7a53b4-f321-44ff-9125-741de269b710)

This PR adds 1% margin for the left side of the text, which should be small enough to not too be noticeable and give the scrollbar space.
![image](https://github.com/lun-4/obsidian2web/assets/126194895/8b9f7c2a-c6ae-442a-bfd0-72f22a73121d)

I'm unsure if this project has a preferred unit size for this, so I went with percentage. Feel free to edit it into an preferred unit. 