### PR TITLE
Implement image scaling for crosslinks

### DIFF
--- a/src/processors.zig
+++ b/src/processors.zig
@@ -185,10 +185,10 @@ pub const CrossPageLinkProcessor = struct {
         maybe_scale: ?[]const u8,
     ) !void {
         if (maybe_scale) |scale| {
-            if (parseResolutionFromAlt(scale)) |res| {
+            if (parseResolution(scale)) |res| {
                 try pctx.out.print("alt=\"{s}\"", .{alt_text});
                 try pctx.out.print("width=\"{s}\"", .{res[0].?});
-                if (res[1] != null) try pctx.out.print("height=\"{s}\"", .{res[1].?});
+                if (res[1]) |height| try pctx.out.print("height=\"{s}\"", .{height});
                 return;
             }
 
@@ -198,19 +198,20 @@ pub const CrossPageLinkProcessor = struct {
             return;
         }
 
-        if (parseResolutionFromAlt(alt_text)) |res| {
+        if (parseResolution(alt_text)) |res| {
             try pctx.out.print("width=\"{s}\"", .{res[0].?});
-            if (res[1] != null) try pctx.out.print("height=\"{s}\"", .{res[1].?});
+            if (res[1]) |height| try pctx.out.print("height=\"{s}\"", .{height});
             return;
         }
 
         try pctx.out.print("alt=\"{s}\"", .{alt_text});
     }
 
-    fn parseResolutionFromAlt(alt: []const u8) ?[2]?[]const u8 {
+    fn parseResolution(alt: []const u8) ?[2]?[]const u8 {
         _ = std.fmt.parseInt(i32, alt, 10) catch {
             var resolutionSplit = std.mem.split(u8, alt, "x");
             const width = resolutionSplit.next();
+            if (width == null) return null;
             const height = resolutionSplit.next();
 
             _ = std.fmt.parseInt(i32, width.?, 10) catch return null;

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -189,6 +189,8 @@ pub const CrossPageLinkProcessor = struct {
                 .resolution => |resolution| {
                     try pctx.out.print("width=\"{d}\"", .{resolution.width});
                     if (resolution.height) |height| try pctx.out.print("height=\"{d}\"", .{height});
+                    try pctx.out.print("alt=\"{s}\"", .{alt_text});
+                    return;
                 },
                 .alt_text => |thirdpos_alt_text| {
                     // Third position must be a resolution else treat scale as literal value of alt text instead
@@ -196,8 +198,6 @@ pub const CrossPageLinkProcessor = struct {
                     return;
                 },
             }
-            try pctx.out.print("alt=\"{s}\"", .{alt_text});
-            return;
         }
 
         const res = parseResolution(alt_text);

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -213,19 +213,19 @@ pub const CrossPageLinkProcessor = struct {
     }
 
     fn parseResolution(alt: []const u8) AltResult {
-        const widthExclusively = std.fmt.parseInt(i32, alt, 10) catch {
-            var resolutionSplit = std.mem.split(u8, alt, "x");
-            const width = resolutionSplit.next() orelse return AltResult{ .alt_text = alt };
-            const widthInt = std.fmt.parseInt(i32, width, 10) catch return AltResult{ .alt_text = alt };
-            const heightMaybe = resolutionSplit.next();
+        const width_exclusively = std.fmt.parseInt(i32, alt, 10) catch {
+            var resolution_split = std.mem.split(u8, alt, "x");
+            const width = resolution_split.next() orelse return AltResult{ .alt_text = alt };
+            const width_int = std.fmt.parseInt(i32, width, 10) catch return AltResult{ .alt_text = alt };
+            const height_maybe = resolution_split.next();
 
-            var heightInt: ?isize = null;
-            if (heightMaybe) |heightChars| heightInt = std.fmt.parseInt(i32, heightChars, 10) catch null;
+            var height_int: ?isize = null;
+            if (height_maybe) |heightChars| height_int = std.fmt.parseInt(i32, heightChars, 10) catch null;
 
-            return AltResult{ .resolution = ExplicitResolution{ .width = widthInt, .height = heightInt } };
+            return AltResult{ .resolution = ExplicitResolution{ .width = width_int, .height = height_int } };
         };
 
-        return AltResult{ .resolution = ExplicitResolution{ .width = widthExclusively, .height = null } };
+        return AltResult{ .resolution = ExplicitResolution{ .width = width_exclusively, .height = null } };
     }
 };
 

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -186,13 +186,13 @@ pub const CrossPageLinkProcessor = struct {
         if (maybe_scale) |scale| {
             const res = parseResolution(scale);
             switch (res) {
-                .resolution => {
-                    try pctx.out.print("width=\"{d}\"", .{res.resolution.width});
-                    if (res.resolution.height) |height| try pctx.out.print("height=\"{d}\"", .{height});
+                .resolution => |resolution| {
+                    try pctx.out.print("width=\"{d}\"", .{resolution.width});
+                    if (resolution.height) |height| try pctx.out.print("height=\"{d}\"", .{height});
                 },
-                .alt_text => {
+                .alt_text => |thirdpos_alt_text| {
                     // Third position must be a resolution else treat scale as literal value of alt text instead
-                    try pctx.out.print("alt=\"{s}|{s}\"", .{ alt_text, scale });
+                    try pctx.out.print("alt=\"{s}|{s}\"", .{ alt_text, thirdpos_alt_text });
                     return;
                 },
             }
@@ -202,12 +202,12 @@ pub const CrossPageLinkProcessor = struct {
 
         const res = parseResolution(alt_text);
         switch (res) {
-            .resolution => {
-                try pctx.out.print("width=\"{d}\"", .{res.resolution.width});
-                if (res.resolution.height) |height| try pctx.out.print("height=\"{d}\"", .{height});
+            .resolution => |resolution| {
+                try pctx.out.print("width=\"{d}\"", .{resolution.width});
+                if (resolution.height) |height| try pctx.out.print("height=\"{d}\"", .{height});
             },
-            .alt_text => {
-                try pctx.out.print("alt=\"{s}\"", .{alt_text});
+            .alt_text => |given_alt_text| {
+                try pctx.out.print("alt=\"{s}\"", .{given_alt_text});
             },
         }
     }

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -210,11 +210,10 @@ pub const CrossPageLinkProcessor = struct {
     fn parseResolution(alt: []const u8) ?[2]?[]const u8 {
         _ = std.fmt.parseInt(i32, alt, 10) catch {
             var resolutionSplit = std.mem.split(u8, alt, "x");
-            const width = resolutionSplit.next();
-            if (width == null) return null;
+            const width = resolutionSplit.next() orelse return null;
             const height = resolutionSplit.next();
 
-            _ = std.fmt.parseInt(i32, width.?, 10) catch return null;
+            _ = std.fmt.parseInt(i32, width, 10) catch return null;
             return .{ width, height };
         };
 


### PR DESCRIPTION
First foray into Zig so I apologize if this code reads awkwardly, feel free to edit it to something you like more if it's not a hassle.

This partially implements #43, the same would have to be done for external `![alt](url)` style links, `parseAltText` can probably be extracted for this but I think that it would require more work outside of my depth.
