### PR TITLE
use source pcre build

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
         .@"libpcre.zig" = .{
-            .url = "https://github.com/lun-4/libpcre.zig/archive/0d2cbde3ce67345bd6777d321e8601e7fddf234f.tar.gz",
-            .hash = "122073991740145418bd4ecea59c5f885b1fb92def243ac6ef803978d53cbf2d6d18",
+            .url = "https://github.com/lun-4/libpcre.zig/archive/96820464cd6ee81137ad675c5fe2bd0923bdf782.tar.gz",
+            .hash = "12205450f9f1ca3cd8f44b3e329f884dac7b38fc323e00866b3897790c4f0f3cdff0",
         },
         .chrono = .{
             .url = "https://github.com/leroycep/chrono-zig/archive/bedd9339af9b05c240956b137cb1a5b67a9b74b7.tar.gz",
@@ -16,8 +16,8 @@
             .hash = "12206275494db106adf893d237dda64130436e36cb91b60ddc960bd50b938690a8dc",
         },
         .koino = .{
-            .url = "https://github.com/lun-4/koino/archive/147a4d934370bc458d7d9bdf3e77b0be624a443d.tar.gz",
-            .hash = "1220e2cf35485492f97788effa9c9364af6d6df25ecd832e79fbc06155fdbc0759e2",
+            .url = "https://github.com/lun-4/koino/archive/b95604c13d4189030221e0362d9ad3227e7be764.tar.gz",
+            .hash = "1220d39125a0b58fe8ab403114fcc1e5d307266ccc6de0712ee89086e5c7cba037d7",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
         .@"libpcre.zig" = .{
-            .url = "https://github.com/kivikakk/libpcre.zig/archive/9522ad9bcce76ce608ac62097450d4eac7436d9c.tar.gz",
-            .hash = "1220fa274f41744bc60b284f9264705f772b98afd2ed219cebb6cec744422e8e2692",
+            .url = "https://github.com/lun-4/libpcre.zig/archive/0d2cbde3ce67345bd6777d321e8601e7fddf234f.tar.gz",
+            .hash = "122073991740145418bd4ecea59c5f885b1fb92def243ac6ef803978d53cbf2d6d18",
         },
         .chrono = .{
             .url = "https://github.com/leroycep/chrono-zig/archive/bedd9339af9b05c240956b137cb1a5b67a9b74b7.tar.gz",
@@ -16,8 +16,8 @@
             .hash = "12206275494db106adf893d237dda64130436e36cb91b60ddc960bd50b938690a8dc",
         },
         .koino = .{
-            .url = "https://github.com/lun-4/koino/archive/e1acea70701207c5830b88389f147d9fd1f0e01c.tar.gz",
-            .hash = "122002f94548aa45fac670d07ddee72235acdf7aad770daaf1bc4b7b309241f54a8c",
+            .url = "https://github.com/lun-4/koino/archive/147a4d934370bc458d7d9bdf3e77b0be624a443d.tar.gz",
+            .hash = "1220e2cf35485492f97788effa9c9364af6d6df25ecd832e79fbc06155fdbc0759e2",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
         .@"libpcre.zig" = .{
-            .url = "https://github.com/lun-4/libpcre.zig/archive/96820464cd6ee81137ad675c5fe2bd0923bdf782.tar.gz",
-            .hash = "12205450f9f1ca3cd8f44b3e329f884dac7b38fc323e00866b3897790c4f0f3cdff0",
+            .url = "https://github.com/lun-4/libpcre.zig/archive/059892bf72e2da9566fbb3c7a75ea2dd3f9527c6.tar.gz",
+            .hash = "12203a5f2c4f9639543bf89389ec6e6a91f424a57cbd3d44cb957d5bc712022fe4a3",
         },
         .chrono = .{
             .url = "https://github.com/leroycep/chrono-zig/archive/bedd9339af9b05c240956b137cb1a5b67a9b74b7.tar.gz",
@@ -16,8 +16,8 @@
             .hash = "12206275494db106adf893d237dda64130436e36cb91b60ddc960bd50b938690a8dc",
         },
         .koino = .{
-            .url = "https://github.com/lun-4/koino/archive/b95604c13d4189030221e0362d9ad3227e7be764.tar.gz",
-            .hash = "1220d39125a0b58fe8ab403114fcc1e5d307266ccc6de0712ee89086e5c7cba037d7",
+            .url = "https://github.com/lun-4/koino/archive/82ddcdac0368c7b92902309b37b7a161b33c80a7.tar.gz",
+            .hash = "12203b017be6a8601ab4ceea8fc4188fcddbd27fc982223b2cad59460104496e6f7e",
         },
     },
     .paths = .{


### PR DESCRIPTION
close #41

the following works with this PR:
```
$ zig build -Dtarget=x86_64-linux-native -Dcpu=baseline -Doptimize=ReleaseSafe
$ ldd ./zig-out/bin/obsidian2web
# ... no sight of libpcre ...
# :D
```

targeting musl ~~does not work (TODO fix pcre.h not being included properly)~~ works now:
```
$ zig build -Dtarget=x86_64-linux-musl -Dcpu=baseline -Doptimize=ReleaseSafe
$ ldd ./zig-out/bin/obsidian2web
        not a dynamic executable
```

depends on https://github.com/kivikakk/libpcre.zig/pull/20