### PR TITLE
fix files with same basename

### DIFF
--- a/src/Page.zig
+++ b/src/Page.zig
@@ -27,7 +27,7 @@ pub const State = union(enum) {
     post: void,
 };
 
-pub const PageType = enum { md, canvas };
+pub const PageType = enum { md, canvas, asset };
 
 pub const PageAttributes = struct {
     ctime: i64,
@@ -156,6 +156,14 @@ pub const PageAttributes = struct {
     }
 };
 
+pub fn relativePathWithoutExtension(self: Self) []const u8 {
+    return switch (self.page_type) {
+        .asset => unreachable,
+        .md => self.filesystem_path[0 .. self.filesystem_path.len - 3],
+        .canvas => self.filesystem_path[0 .. self.filesystem_path.len - 7],
+    };
+}
+
 /// assumes given path is a ".md" file.
 pub fn fromPath(ctx: *const Context, fspath: []const u8) !Self {
     const title_offset: usize =
@@ -177,6 +185,22 @@ pub fn fromPath(ctx: *const Context, fspath: []const u8) !Self {
         .filesystem_path = fspath,
         .attributes = attributes,
         .title = title,
+    };
+}
+
+pub fn fromAssetPath(ctx: *const Context, fspath: []const u8) !Self {
+    logger.info("create asset with fspath {s}", .{fspath});
+
+    var file = try std.fs.cwd().openFile(fspath, .{});
+    defer file.close();
+    const attributes = try PageAttributes.fromFile(file);
+
+    return Self{
+        .page_type = .asset,
+        .ctx = ctx,
+        .filesystem_path = fspath,
+        .attributes = attributes,
+        .title = "",
     };
 }
 
@@ -235,6 +259,7 @@ pub fn fetchHtmlPath(self: Self, allocator: std.mem.Allocator) ![]const u8 {
             ".canvas",
             ".html",
         ),
+        .asset => unreachable,
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -174,7 +174,7 @@ pub const Context = struct {
     vault_dir: std.fs.Dir,
     arenas: ArenaHolder,
     pages: PageMap,
-    titles: TitleMap,
+    assets: PageMap,
     fspaths: OwnedStringList,
     tree: PathTree,
 
@@ -191,7 +191,7 @@ pub const Context = struct {
             .vault_dir = vault_dir,
             .arenas = ArenaHolder.init(allocator),
             .pages = PageMap.init(allocator),
-            .titles = TitleMap.init(allocator),
+            .assets = PageMap.init(allocator),
             .tree = PathTree.init(allocator),
             .fspaths = OwnedStringList.init(allocator),
         };
@@ -203,8 +203,12 @@ pub const Context = struct {
             var it = self.pages.iterator();
             while (it.next()) |entry| entry.value_ptr.deinit();
         }
+        {
+            var it = self.assets.iterator();
+            while (it.next()) |entry| entry.value_ptr.deinit();
+        }
         self.pages.deinit();
-        self.titles.deinit();
+        self.assets.deinit();
         self.tree.deinit();
         self.fspaths.deinit();
     }
@@ -220,33 +224,26 @@ pub const Context = struct {
         const must_render =
             std.mem.endsWith(u8, path, ".md") or std.mem.endsWith(u8, path, ".canvas");
 
-        if (!must_render) {
-            const basename = std.fs.path.basename(owned_fspath);
-
-            const titles_result = try self.titles.getOrPut(basename);
-            if (!titles_result.found_existing) {
-                titles_result.value_ptr.* = owned_fspath;
+        if (must_render) {
+            const pages_result = try self.pages.getOrPut(owned_fspath);
+            if (!pages_result.found_existing) {
+                const page = try Page.fromPath(self, owned_fspath);
+                pages_result.value_ptr.* = page;
+                //try self.titles.put(page.title, page.filesystem_path);
+                try self.tree.addPath(page.filesystem_path);
             }
-
-            try self.fspaths.append(owned_fspath);
-            return;
-        }
-
-        const pages_result = try self.pages.getOrPut(owned_fspath);
-        if (!pages_result.found_existing) {
-            const page = try Page.fromPath(self, owned_fspath);
-            pages_result.value_ptr.* = page;
-            try self.titles.put(page.title, page.filesystem_path);
-            try self.tree.addPath(page.filesystem_path);
+        } else {
+            // don't render, instead create as an Asset (a variant of Page)
+            const assets_result = try self.assets.getOrPut(owned_fspath);
+            if (!assets_result.found_existing) {
+                const asset = try Page.fromAssetPath(self, owned_fspath);
+                assets_result.value_ptr.* = asset;
+            }
         }
     }
 
     pub fn pageFromPath(self: Self, path: []const u8) ?Page {
         return self.pages.get(path);
-    }
-
-    pub fn pageFromTitle(self: Self, title: []const u8) ?Page {
-        return self.pages.get(self.titles.get(title) orelse return null);
     }
 
     pub fn webPath(
@@ -374,20 +371,23 @@ pub fn main() anyerror!void {
         }
     }
 
-    try std.fs.cwd().makePath("public/images");
-    var titles_it = ctx.titles.iterator();
-    while (titles_it.next()) |entry| {
-        const fspath = entry.value_ptr.*;
-        // TODO (DO NOT MERGE): attempt to create unique names inside images (w/ folder paths?)
-        const maybe_page = ctx.pages.get(fspath);
-        if (maybe_page != null) continue;
+    try std.fs.cwd().makePath("public/assets");
+    var assets_it = ctx.assets.iterator();
+    while (assets_it.next()) |entry| {
+        const asset: Page = entry.value_ptr.*;
         var output_path_buffer: [std.posix.PATH_MAX]u8 = undefined;
         const output_path = try std.fmt.bufPrint(
             &output_path_buffer,
-            "public/images/{s}",
-            .{std.fs.path.basename(fspath)},
+            "public/assets/{s}",
+            .{asset.relativePath()},
         );
-        try std.fs.cwd().copyFile(fspath, std.fs.cwd(), output_path, .{});
+
+        const leading_path_to_file = std.fs.path.dirname(output_path).?;
+        logger.info("mkdir asset {s}", .{leading_path_to_file});
+        try std.fs.cwd().makePath(leading_path_to_file);
+
+        logger.info("cp asset {s} -> {s}", .{ asset.filesystem_path, output_path });
+        try std.fs.cwd().copyFile(asset.filesystem_path, std.fs.cwd(), output_path, .{});
     }
 
     // end processors are for features that only work once *all* pages
@@ -667,6 +667,7 @@ pub fn mainPass(ctx: *Context, page: *Page) !void {
             \\  <main class="text">
         , .{});
         switch (page.page_type) {
+            .asset => unreachable,
             .md => {
                 try output.print(
                     \\    <h2>{s}</h2><p>

--- a/src/main.zig
+++ b/src/main.zig
@@ -175,6 +175,7 @@ pub const Context = struct {
     arenas: ArenaHolder,
     pages: PageMap,
     titles: TitleMap,
+    fspaths: OwnedStringList,
     tree: PathTree,
 
     const Self = @This();
@@ -192,6 +193,7 @@ pub const Context = struct {
             .pages = PageMap.init(allocator),
             .titles = TitleMap.init(allocator),
             .tree = PathTree.init(allocator),
+            .fspaths = OwnedStringList.init(allocator),
         };
     }
 
@@ -204,6 +206,7 @@ pub const Context = struct {
         self.pages.deinit();
         self.titles.deinit();
         self.tree.deinit();
+        self.fspaths.deinit();
     }
 
     pub fn pathAllocator(self: *Self) std.mem.Allocator {
@@ -225,6 +228,7 @@ pub const Context = struct {
                 titles_result.value_ptr.* = owned_fspath;
             }
 
+            try self.fspaths.append(owned_fspath);
             return;
         }
 
@@ -371,16 +375,24 @@ pub fn main() anyerror!void {
     }
 
     try std.fs.cwd().makePath("public/images");
-    var titles_it = ctx.titles.iterator();
-    while (titles_it.next()) |entry| {
-        const fspath = entry.value_ptr.*;
+    for (ctx.fspaths.items) |fspath| {
         const maybe_page = ctx.pages.get(fspath);
         if (maybe_page != null) continue;
+        // TODO UGLY HACK SHOULD REMOVE IT
+        const vault_path = ctx.build_file.vault_path;
+        const include_relpath = ctx.build_file.includes.items[0];
+        var include_fspath_buf: [std.posix.PATH_MAX]u8 = undefined;
+        const include_fspath = try std.fmt.bufPrint(
+            &include_fspath_buf,
+            "{s}/{s}",
+            .{ vault_path, include_relpath },
+        );
+        const stripped_fspath = util.stripLeft(fspath, include_fspath);
         var output_path_buffer: [std.posix.PATH_MAX]u8 = undefined;
         const output_path = try std.fmt.bufPrint(
             &output_path_buffer,
             "public/images/{s}",
-            .{std.fs.path.basename(fspath)},
+            .{stripped_fspath},
         );
         try std.fs.cwd().copyFile(fspath, std.fs.cwd(), output_path, .{});
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -375,24 +375,17 @@ pub fn main() anyerror!void {
     }
 
     try std.fs.cwd().makePath("public/images");
-    for (ctx.fspaths.items) |fspath| {
+    var titles_it = ctx.titles.iterator();
+    while (titles_it.next()) |entry| {
+        const fspath = entry.value_ptr.*;
+        // TODO (DO NOT MERGE): attempt to create unique names inside images (w/ folder paths?)
         const maybe_page = ctx.pages.get(fspath);
         if (maybe_page != null) continue;
-        // TODO UGLY HACK SHOULD REMOVE IT
-        const vault_path = ctx.build_file.vault_path;
-        const include_relpath = ctx.build_file.includes.items[0];
-        var include_fspath_buf: [std.posix.PATH_MAX]u8 = undefined;
-        const include_fspath = try std.fmt.bufPrint(
-            &include_fspath_buf,
-            "{s}/{s}",
-            .{ vault_path, include_relpath },
-        );
-        const stripped_fspath = util.stripLeft(fspath, include_fspath);
         var output_path_buffer: [std.posix.PATH_MAX]u8 = undefined;
         const output_path = try std.fmt.bufPrint(
             &output_path_buffer,
             "public/images/{s}",
-            .{stripped_fspath},
+            .{std.fs.path.basename(fspath)},
         );
         try std.fs.cwd().copyFile(fspath, std.fs.cwd(), output_path, .{});
     }

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -98,13 +98,24 @@ pub const CrossPageLinkProcessor = struct {
             const maybe_alt_text = reference_it.next();
             const maybe_scale = reference_it.next();
 
-            const fspath = ctx.titles.get(referenced_file_basename) orelse {
+            var maybe_fspath: ?[]const u8 = null;
+            for (ctx.fspaths.items) |fspath| {
+                logger.debug("{s} ::: {s}", .{ fspath, referenced_file_basename });
+                if (std.mem.endsWith(u8, fspath, referenced_file_basename)) {
+                    maybe_fspath = fspath;
+                    break;
+                }
+            }
+
+            if (maybe_fspath == null) {
                 logger.err(
                     "referenced name: '{s}' not found",
                     .{referenced_file_basename},
                 );
                 return error.InvalidLinksFound;
-            };
+            }
+            const fspath = maybe_fspath.?;
+
             const maybe_page = ctx.pages.get(fspath);
             if (maybe_page != null) {
                 logger.err(

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -85,58 +85,49 @@ pub const CrossPageLinkProcessor = struct {
 
         if (full_link_text[0] == '!') {
 
-            // inline link to vault file
+            // inline link to vault file (as an unrenderable page AKA asset)
             const raw_reference = file_contents[match.start + 3 .. match.end - 2];
             var reference_it = std.mem.splitSequence(u8, raw_reference, "|");
-            var referenced_file_basename = reference_it.next() orelse {
+            const referenced_file = reference_it.next() orelse {
                 logger.err(
                     "no name given to crosslink. raw ref '{s}'",
                     .{raw_reference},
                 );
                 return error.InvalidLinksFound;
             };
-            // TODO (DO NOT MERGE, HACK): basenaming so files arent broken
-            referenced_file_basename = std.fs.path.basename(referenced_file_basename);
+
             const maybe_alt_text = reference_it.next();
             const maybe_scale = reference_it.next();
 
-            var maybe_fspath: ?[]const u8 = null;
-            for (ctx.fspaths.items) |fspath| {
-                logger.debug("{s} ::: {s}", .{ fspath, referenced_file_basename });
-                if (std.mem.endsWith(u8, fspath, referenced_file_basename)) {
-                    maybe_fspath = fspath;
+            var maybe_asset: ?*Page = null;
+            var assets_it = ctx.assets.iterator();
+            while (assets_it.next()) |entry| {
+                const asset: *Page = entry.value_ptr;
+                const fspath = asset.filesystem_path;
+                logger.debug("{s} ::: {s}", .{ fspath, referenced_file });
+                if (std.mem.endsWith(u8, fspath, referenced_file)) {
+                    maybe_asset = asset;
                     break;
                 }
             }
 
-            if (maybe_fspath == null) {
+            if (maybe_asset == null) {
                 logger.err(
                     "referenced name: '{s}' not found",
-                    .{referenced_file_basename},
+                    .{referenced_file},
                 );
                 return error.InvalidLinksFound;
             }
-            const fspath = maybe_fspath.?;
+            const asset = maybe_asset.?;
 
-            const maybe_page = ctx.pages.get(fspath);
-            if (maybe_page != null) {
-                logger.err(
-                    "referenced name: {s} is not an inline-able file, but a page.",
-                    .{referenced_file_basename},
-                );
-                return error.InvalidLinksFound;
-            }
-
-            logger.info("inlining media content @ {s}", .{fspath});
-
-            const file_type = try tinymagic.fileTypeFromPath(fspath);
-
+            logger.info("inlining media content @ {s}", .{asset.filesystem_path});
+            const file_type = try tinymagic.fileTypeFromPath(asset.filesystem_path);
             switch (file_type) {
                 .image => {
                     try pctx.out.print(
                         "<img src=\"{s}\"",
                         .{
-                            ctx.webPath("/images/{s}", .{referenced_file_basename}),
+                            ctx.webPath("/assets/{s}", .{asset.relativePath()}),
                         },
                     );
                     if (maybe_alt_text) |alt_text| {
@@ -151,22 +142,41 @@ pub const CrossPageLinkProcessor = struct {
                 .video => try pctx.out.print(
                     "<video src=\"{s}\" controls>",
                     .{
-                        ctx.webPath("/images/{s}", .{referenced_file_basename}),
+                        ctx.webPath("/assets/{s}", .{asset.relativePath()}),
                     },
                 ),
             }
         } else {
             // link to page
 
-            const referenced_title = file_contents[match.start + 2 .. match.end - 2];
+            const reference = file_contents[match.start + 2 .. match.end - 2];
             logger.debug(
                 "{s} has link to '{s}'",
-                .{ pctx.page.title, referenced_title },
+                .{ pctx.page.title, reference },
             );
 
-            const maybe_page_local_path = ctx.titles.get(referenced_title);
-            if (maybe_page_local_path) |page_local_path| {
-                var referenced_page = ctx.pages.get(page_local_path).?;
+            var maybe_page: ?*Page = null;
+            var pages_it = ctx.pages.iterator();
+            while (pages_it.next()) |entry| {
+                const page: *Page = entry.value_ptr;
+                const fspath = page.filesystem_path;
+                logger.debug("PAGE {s} :: COMPARE :: {s}", .{ fspath, reference });
+                if (std.mem.endsWith(u8, fspath, reference)) {
+                    maybe_page = page;
+                    break;
+                }
+
+                // pages' fspaths ends in .md or .canvas but we don't
+                // reference .md or .canvas, instead use a stripped path without those
+                const relpath = page.relativePathWithoutExtension();
+                logger.debug("PAGE REL {s} :: COMPARE :: {s}", .{ relpath, reference });
+                if (std.mem.endsWith(u8, relpath, reference)) {
+                    maybe_page = page;
+                    break;
+                }
+            }
+
+            if (maybe_page) |referenced_page| {
                 const web_path = try referenced_page.fetchWebPath(pctx.ctx.allocator);
                 defer pctx.ctx.allocator.free(web_path);
 
@@ -179,18 +189,18 @@ pub const CrossPageLinkProcessor = struct {
                     "<a href=\"{}\">{s}</a>",
                     .{
                         ctx.webPath("/{s}", .{web_path}),
-                        util.unsafeHTML(referenced_title),
+                        util.unsafeHTML(reference),
                     },
                 );
             } else {
                 if (ctx.build_file.config.strict_links) {
                     logger.err(
-                        "file '{s}' has link to file '{s}' which is not included!",
-                        .{ pctx.page, referenced_title },
+                        "file '{s}' has link to file '{s}' which is not included as a page!",
+                        .{ pctx.page, reference },
                     );
                     return error.InvalidLinksFound;
                 } else {
-                    try pctx.out.print("[[{s}]]", .{referenced_title});
+                    try pctx.out.print("[[{s}]]", .{reference});
                 }
             }
         }

--- a/src/processors.zig
+++ b/src/processors.zig
@@ -88,13 +88,15 @@ pub const CrossPageLinkProcessor = struct {
             // inline link to vault file
             const raw_reference = file_contents[match.start + 3 .. match.end - 2];
             var reference_it = std.mem.splitSequence(u8, raw_reference, "|");
-            const referenced_file_basename = reference_it.next() orelse {
+            var referenced_file_basename = reference_it.next() orelse {
                 logger.err(
                     "no name given to crosslink. raw ref '{s}'",
                     .{raw_reference},
                 );
                 return error.InvalidLinksFound;
             };
+            // TODO (DO NOT MERGE, HACK): basenaming so files arent broken
+            referenced_file_basename = std.fs.path.basename(referenced_file_basename);
             const maybe_alt_text = reference_it.next();
             const maybe_scale = reference_it.next();
 


### PR DESCRIPTION
refactor how non-markdown/non-canvas files work into an Asset (which is a type of Page).

remove `ctx.titles` and instead make link resolution work based on the actual paths of things, this lets two files with same basename be still linkable if you do `![[folder1/path1.png]]` and `![[folder2/path1.png]]` in the links